### PR TITLE
Fix envc transfer from host to guest with uhyve

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -386,7 +386,7 @@ static int initd(void* arg)
 		for(i=0; i<uhyve_cmdsize.envc-1; i++)
 			uhyve_cmdval_phys.envp[i] = (char*) virt_to_phys((size_t) uhyve_cmdval.envp[i]);
 		// the last element is always NULL
-		uhyve_cmdval_phys.envp[uhyve_cmdsize.envc-1] = NULL;
+		uhyve_cmdval.envp[uhyve_cmdsize.envc-1] = NULL;
 		uhyve_cmdval_phys.envp = (char**) virt_to_phys((size_t) uhyve_cmdval_phys.envp);
 
 		uhyve_send(UHYVE_PORT_CMDVAL,


### PR DESCRIPTION
A `NULL` value marks the end of the environment variables array on the stack. It is currently missing when uhyve transfers the environment variables from the host, due to what I believe to be a typo.
`uhyve_cmdval_phys` is supposed to represent the physical addresses of `uhyve_cmdval` so that uhyve can write the correct values at the correct locations. The `NULL` value marking the end of the array should be set in `uhyve_cmdval.envp` rather than `uhyve_cmdval_phys.envp`.

Newlib implements `getenv` by iterating over that array until it reaches `NULL`, so when that marker is absent, it leads to an overflow on the stack.